### PR TITLE
More CSS variables and dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+venv/
+app.pid

--- a/Static/CSS/log.css
+++ b/Static/CSS/log.css
@@ -25,6 +25,7 @@
     text-align: left;
     cursor:pointer;
     position: relative;
+    color:white;
 }
 
 .logfile:hover {

--- a/Static/CSS/main.css
+++ b/Static/CSS/main.css
@@ -48,6 +48,7 @@ body {
 .header-actions button:hover, .header-actions a:hover {
     border: 1px solid var(--header-menu-border-hover-color);
     background-color: var(--header-menu-background-hover-color);
+    color: var(--header-menu-foreground-hover-color);
 }
 
 .header-actions button i, .header-actions a i {
@@ -71,7 +72,7 @@ body {
     padding: 15px;
     font-size: 14px;
     font-weight: 300;
-    background: transparent;
+    background-color: var(--menu-background-color);
     border: none;
     border-right: 0.5px solid var(--menu-border-color);
     color: var(--menu-foreground-color);

--- a/Static/CSS/tables.css
+++ b/Static/CSS/tables.css
@@ -13,6 +13,7 @@
     overflow-y: auto;
     overflow-x: hidden;
     height: calc(100% - 36px);
+    color: var(--table-data-foreground-color);
 }
 .data-table tbody tr {
     width: 100%;
@@ -60,8 +61,10 @@
     position: relative;
     transform: translateY(-50%);
     vertical-align: top;
+    color: var(--table-info-foreground-color);
 }
 .data-table th {
     border: 0;
     border-bottom: 2px solid #4f4f4f;
+    color:var(--table-data-foreground-color);
 }

--- a/Static/CSS/theme-dark.css
+++ b/Static/CSS/theme-dark.css
@@ -10,45 +10,47 @@
         --color-pink: rgba(237, 105, 125, 1);
 
         --foreground-color: white;
-        --background-color: rgba(232, 217, 183, 0.3);
+        --background-color: #3b444b;
 
         --header-foreground-color: white;
-        --header-background-color: #565654;
+        --header-background-color: #353839;
 
         --header-menu-foreground-color: white;
-        --header-menu-background-color: rgba(255,255,255,0.05);
+        --header-menu-background-color: #414a4c;
         --header-menu-border-color: rgba(255,255,255,0.1);
 
-        --header-menu-foreground-hover-color: white;
-        --header-menu-background-hover-color: rgba(255,255,255,0.1);
+        --header-menu-foreground-hover-color: #414a4c;
+        --header-menu-background-hover-color: white;
         --header-menu-border-hover-color: rgba(255,255,255,0.15);
 
-        --menu-foreground-color: rgba(0,0,0,0.6);
-        --menu-background-color: #E0DBD2;
+        --menu-foreground-color: white;
+        --menu-background-color: #414a4c;
         --menu-border-color: rgba(0,0,0,0.4);
 
-        --menu-foreground-hover-color: rgba(255,255,255,0.8);
-        --menu-background-hover-color: rgba(0,0,0,0.2);
+        --menu-foreground-hover-color: #414a4c;
+        --menu-background-hover-color: white;
         --menu-border-hover-color: rgba(0,0,0,0.4);
 
         --section-header-foreground-color: white;
         --section-header-background-color: white;
 
-        --widget-header-foreground-color: black;
-        --widget-header-background-color: white;
-        --widget-header-font-weight: 300;
+        --widget-header-foreground-color: white;
+        --widget-header-background-color: #353839;
+        --widget-header-font-weight: 400;
 
         --widget-foreground-color: white;
-        --widget-background-color: white;
+        --widget-background-color: #414a4c;
         --widget-border-color: white;
 
         --widget-grid-item-foreground-color: white; 
-        --widget-grid-item-background-color: #4c4c4c; 
+        --widget-grid-item-background-color: #323232;
 
         --table-odd-row-color: white;
         --table-even-row-color: white;
         --table-border-color: white;
 
-        --table-data-foreground-color: black;
-        --table-info-foreground-color: black;
+        --table-data-foreground-color: white;
+        --table-info-foreground-color: white;
+
 }
+

--- a/Static/CSS/widget-grid.css
+++ b/Static/CSS/widget-grid.css
@@ -8,7 +8,7 @@
     border-top:0;
     border-bottom:0;
     box-sizing: border-box;
-    background-color: rgba(255,255,255,0.7);
+    background-color: var(--widget-background-color);
 }
 .widget-grid-item {
     font-size: 12px;
@@ -24,7 +24,8 @@
     width: 100%;
     height: 100%;
     position: relative;
-    background-color: rgba(255,255,255,0.9);
+    background-color: var(--widget-background-color);
+    color: var(--widget-foreground-color);
     font-size: 0;
     margin-bottom: 42px;
 }
@@ -63,8 +64,8 @@
 
 .widget-grid-item h1 {
     font-size: 18px;
-    color: white;
-    background: rgba(0,0,0,0.7);
+    color: var(--widget-grid-item-foreground-color);
+    background: var(--widget-grid-item-background-color);
     margin:0;
     padding: 10px 16px;
     position: absolute;
@@ -88,11 +89,12 @@
     width: 100%;
     padding: 12px;
     font-size: 18px;
-    font-weight: 200;
+    font-weight: var(--widget-header-font-weight);
     border: 0.5px solid rgba(0,0,0,0.1);
     border-left: none;
     border-right: none;
-    background-color: white;
+    background-color: var(--widget-header-background-color);
+    color: var(--widget-header-foreground-color);
     box-sizing: border-box;
 }
 

--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ class Root(object): pass
 
 class Server(object):
     default_conf = {
-        "theme": "dark"
+        "theme": "default"
     }
     def __init__(self, conf):
         self.conf = copy(self.__class__.default_conf)

--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ class Root(object): pass
 
 class Server(object):
     default_conf = {
-        "theme": "default"
+        "theme": "dark"
     }
     def __init__(self, conf):
         self.conf = copy(self.__class__.default_conf)

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "host": "0.0.0.0",
     "port": 8080,
-    "css": "main.css"
+    "theme": "dark"
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "host": "0.0.0.0",
     "port": 8080,
-    "theme": "dark"
+    "theme": "default"
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,0 @@
-{
-    "host": "0.0.0.0",
-    "port": 8080,
-    "theme": "default"
-}


### PR DESCRIPTION
* Implemented some unused CSS variables like `widget-header-foreground-color` and `widget-header-background-color` and added CSS variables like `table-data-foreground-color` and `table-info-foreground-color`. 

* Added a dark theme 
![dark-theme](https://user-images.githubusercontent.com/35942108/56589605-95e6e800-65b3-11e9-91b6-093d01f0789a.png)

* Changed `"css": "main.css"` to `"theme": "default"` in the config.

* Added .gitignore for venv and cache files 

Satisfies colour palette on #10 